### PR TITLE
fix security-2875: time constant token comparison using messagedigest…

### DIFF
--- a/src/main/java/com/igalg/jenkins/plugins/mswt/locator/ComputedFolderWebHookTriggerLocator.java
+++ b/src/main/java/com/igalg/jenkins/plugins/mswt/locator/ComputedFolderWebHookTriggerLocator.java
@@ -23,6 +23,9 @@
  */
 package com.igalg.jenkins.plugins.mswt.locator;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +43,8 @@ public class ComputedFolderWebHookTriggerLocator {
 			List<ComputedFolder> candidateProjects  =  jobLocator.getAllComputedFolders();
 		    for (ComputedFolder<?> candidateJob : candidateProjects) {
 		        ComputedFolderWebHookTrigger computedFolderWebHookTrigger = findComputedFolderWebHookTrigger(candidateJob.getTriggers());
-		        if (computedFolderWebHookTrigger != null &&  computedFolderWebHookTrigger.getToken().equals(givenToken)) {
+		        if (computedFolderWebHookTrigger != null &&
+		        		MessageDigest.isEqual(computedFolderWebHookTrigger.getToken().getBytes(UTF_8), givenToken.getBytes(UTF_8))) {
 		        	locatedList.add(new LocatedComputedFolder(candidateJob.getFullName(), computedFolderWebHookTrigger));
 		        }
 		


### PR DESCRIPTION
Hi,
I believe this change could be a potential fix for the security issue SECURITY-2875 highlighted for this plugin and described here: https://www.jenkins.io/security/advisory/2023-10-25/#SECURITY-2875.

The method used to compare the `givenToken` parameter has been changed from the `equals` method provided by the `String` class to the `isEqual` method provided by the `MessageDigest` class.

A comment in the `MessageDigest.isEqual` method implementation states: "The calculation time depends only on the length of digesta. It does not depend on the length of digestb or the contents of digesta and digestb."

In our implementation digesta is the token stored in the `computedFolderWebHookTrigger` and digestb the token passed as parameter to the plugin.
