### PR TITLE
Test with Java 21 and modernization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10
+  target-branch: master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,6 @@
-#!groovy
-
-buildPlugin()
+buildPlugin(
+        useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+        configurations: [
+                [platform: 'linux', jdk: 21],
+                [platform: 'windows', jdk: 17],
+        ])

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
-			<version>2.4.0</version>
+			<version>2.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>2.1.0</version>
+			<version>3.24.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.24.2</version>
+			<version>2.1.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
 		<dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-			<version>1.6.5</version>
+			<version>2.0.9</version>
             <scope>test</scope>
         </dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
-            <version>2.6</version>
+            <version>596.v8c21c963d92d</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>github-api</artifactId>
-			<version>1.116</version>
+			<version>1.314-431.v78d72a_3fe4c3</version>
 			<exclusions>
 				<exclusion>
 					<!-- brought in by io.jenkins.plugins:commons-lang3-api -->

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
 	<scm>
 		<connection>scm:git:https://github.com/jenkinsci/multibranch-scan-webhook-trigger.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/multibranch-scan-webhook-trigger.git</developerConnection>
+		<developerConnection>scm:git:git@github.com:jenkinsci/multibranch-scan-webhook-trigger.git</developerConnection>
 		<url>https://github.com/jenkinsci/multibranch-scan-webhook-trigger.git</url>
 		<tag>HEAD</tag>
 	</scm>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 	<licenses>
 		<license>
 			<name>MIT License</name>
-			<url>http://opensource.org/licenses/MIT</url>
+			<url>https://opensource.org/licenses/MIT</url>
 		</license>
 	</licenses>
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -221,8 +221,14 @@
 			<version>1.6.5</version>
             <scope>test</scope>
         </dependency>
-		
-		
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.7.0</version>
+			<scope>test</scope>
+		</dependency>
+
+
 		<!-- For interactive testing via hpi:run -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.2</version>
+			<version>2.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
@@ -220,7 +220,7 @@
 		<dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-             <!-- <version>1.6.4</version> -->
+			<version>1.6.5</version>
             <scope>test</scope>
         </dependency>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>commons-lang3-api</artifactId>
-			<version>3.12.0-36.vd97de6465d5b_</version>
+			<version>3.13.0-62.v7d18e55f51e2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,8 @@
 		<url>https://github.com/jenkinsci/multibranch-scan-webhook-trigger</url>
 	</issueManagement>
 
-
-
 	<scm>
-		<connection>scm:git:ssh://git@github.com/jenkinsci/multibranch-scan-webhook-trigger.git</connection>
+		<connection>scm:git:https://github.com/jenkinsci/multibranch-scan-webhook-trigger.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/multibranch-scan-webhook-trigger.git</developerConnection>
 		<url>https://github.com/jenkinsci/multibranch-scan-webhook-trigger.git</url>
 		<tag>HEAD</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,6 @@
 		<!--  jenkins.version>2.222.4</jenkins.version>-->
 		<jenkins.version>2.387.3</jenkins.version>
 		<scm-api.version>2.6.4</scm-api.version>
-		<git-plugin.version>4.5.2</git-plugin.version>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<violations.version>1.18</violations.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,17 +3,17 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.18</version>
+		<version>4.75</version>
+		<relativePath/>
 	</parent>
 
 	<properties>
-		<java.level>8</java.level>
 		<!-- <slf4jVersion>1.7.30</slf4jVersion> -->
 		<findbugs.failOnError>false</findbugs.failOnError>
 		<!--  jenkins.version>2.222.4</jenkins.version>-->
-		<jenkins.version>2.263.1</jenkins.version>
-        <scm-api.version>2.6.4</scm-api.version>
-        <git-plugin.version>4.5.2</git-plugin.version>
+		<jenkins.version>2.387.3</jenkins.version>
+		<scm-api.version>2.6.4</scm-api.version>
+		<git-plugin.version>4.5.2</git-plugin.version>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<violations.version>1.18</violations.version>
 	</properties>
@@ -35,28 +35,37 @@
 		</license>
 	</licenses>
 	<developers>
-        <developer>
-            <id>igalg</id>
-            <name>Igal Gluh</name>
-            <email>igal.gluh@gmail.com</email>
-        </developer>
-    </developers>
+		<developer>
+			<id>igalg</id>
+			<name>Igal Gluh</name>
+			<email>igal.gluh@gmail.com</email>
+		</developer>
+	</developers>
 
 	<issueManagement>
 		<system>GitHub</system>
 		<url>https://github.com/jenkinsci/multibranch-scan-webhook-trigger</url>
 	</issueManagement>
 
-	
-
 
 
 	<scm>
-        <connection>scm:git:ssh://git@github.com/jenkinsci/multibranch-scan-webhook-trigger.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/multibranch-scan-webhook-trigger.git</developerConnection>
-        <url>https://github.com/jenkinsci/multibranch-scan-webhook-trigger.git</url>
-    <tag>HEAD</tag>
-  </scm>
+		<connection>scm:git:ssh://git@github.com/jenkinsci/multibranch-scan-webhook-trigger.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/multibranch-scan-webhook-trigger.git</developerConnection>
+		<url>https://github.com/jenkinsci/multibranch-scan-webhook-trigger.git</url>
+		<tag>HEAD</tag>
+	</scm>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-2.387.x</artifactId>
+				<version>2543.vfb_1a_5fb_9496d</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<repositories>
 		<repository>
@@ -121,50 +130,48 @@
 
 	<dependencies>
 		<dependency>
-            <groupId>org.kohsuke</groupId>
-            <artifactId>access-modifier-annotation</artifactId>
-             <!-- <version>1.11</version> -->
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>annotation-indexer</artifactId>
-             <!-- <version>1.12</version> -->
-        </dependency>
-        <!-- <dependency>
+			<groupId>org.kohsuke</groupId>
+			<artifactId>access-modifier-annotation</artifactId>
+			<!-- <version>1.11</version> -->
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci</groupId>
+			<artifactId>annotation-indexer</artifactId>
+			<!-- <version>1.12</version> -->
+		</dependency>
+		<!-- <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <version>1.50</version>
         </dependency> -->
 		
 		
-		 <!-- plugin dependencies -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>${scm-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-api</artifactId>
-            <version>1.116</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <version>${git-plugin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-            <version>2.5.9</version>
-        </dependency>
-        <!-- /plugin dependencies -->
-		
-		
-		
-		
-		
-		
+		<!-- plugin dependencies -->
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>scm-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>github-api</artifactId>
+			<version>1.116</version>
+			<exclusions>
+				<exclusion>
+					<!-- brought in by io.jenkins.plugins:commons-lang3-api -->
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>git</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>branch-api</artifactId>
+		</dependency>
+		<!-- /plugin dependencies -->
 		
 		
 		
@@ -174,6 +181,11 @@
 			<version>2.4.0</version>
 		</dependency>
 		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>commons-lang3-api</artifactId>
+			<version>3.12.0-36.vd97de6465d5b_</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.8.2</version>
@@ -181,12 +193,10 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>structs</artifactId>
-			<version>1.22</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>credentials</artifactId>
-			<version>2.3.19</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.jenkins-ci.plugins</groupId>
@@ -213,25 +223,17 @@
              <!-- <version>1.6.4</version> -->
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <!-- <version>1.6.4</version> -->
-            <scope>test</scope>
-        </dependency>
 		
 		
 		<!-- For interactive testing via hpi:run -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.41</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.92</version>
             <scope>test</scope>
         </dependency>
         
@@ -240,32 +242,27 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.23</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.77</version>
             <scope>test</scope>
         </dependency>
        
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -283,7 +280,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.18</version>
             <scope>test</scope>
         </dependency>
         
@@ -293,12 +289,6 @@
             <version>1.4</version>
             <scope>test</scope>
         </dependency> -->
-		
-		
-		
-		
-		
-		
 		
 		
 		

--- a/src/test/java/com/igalg/jenkins/plugins/mswt/locator/ComputedFolderWebHookTriggerLocatorTest.java
+++ b/src/test/java/com/igalg/jenkins/plugins/mswt/locator/ComputedFolderWebHookTriggerLocatorTest.java
@@ -35,10 +35,9 @@ import java.util.Map;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
 
 import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
 import com.igalg.jenkins.plugins.mswt.trigger.ComputedFolderWebHookTrigger;
@@ -47,8 +46,6 @@ import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 
 @SuppressWarnings("rawtypes")
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({WorkflowMultiBranchProject.class})
 public class ComputedFolderWebHookTriggerLocatorTest {
 	  
 	private List<ComputedFolder> computedFolderList;
@@ -71,6 +68,14 @@ public class ComputedFolderWebHookTriggerLocatorTest {
 			}
 		};
 	  }
+
+  @BeforeEach
+  void setUpStaticMocks() {
+  }
+
+  @AfterEach
+  void tearDownStaticMocks() {
+  }
 
 	  @Test
 	  public void testThatJobsWithMatchedTokenFoundedAndNotMatchNotFounded() {
@@ -95,14 +100,14 @@ public class ComputedFolderWebHookTriggerLocatorTest {
 	  
 	  
 	  private WorkflowMultiBranchProject createJobWorkflowMultiBranchProjectWithouTrigger() {
-			WorkflowMultiBranchProject mock = PowerMockito.mock(WorkflowMultiBranchProject.class);
-			PowerMockito.when(mock.getFullName())
+			WorkflowMultiBranchProject mock = Mockito.mock(WorkflowMultiBranchProject.class);
+			Mockito.when(mock.getFullName())
 	    	.thenReturn("WorkflowMultiBranchProject_noTrigger");
 		    return mock;
 		}  
 	private WorkflowMultiBranchProject createJobWorkflowMultiBranchProject(String token) {
-		WorkflowMultiBranchProject mock = PowerMockito.mock(WorkflowMultiBranchProject.class);
-		PowerMockito.when(mock.getFullName()).thenReturn("WorkflowMultiBranchProject_" + token);
+		WorkflowMultiBranchProject mock = Mockito.mock(WorkflowMultiBranchProject.class);
+		Mockito.when(mock.getFullName()).thenReturn("WorkflowMultiBranchProject_" + token);
 	     Map<TriggerDescriptor, Trigger<?>> triggers = new HashMap<>();
 	     TriggerDescriptor typeDescr = mock(TriggerDescriptor.class);
 	     ComputedFolderWebHookTrigger trigger = new ComputedFolderWebHookTrigger(token);


### PR DESCRIPTION
Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Supersedes #6.
Supersedes #7.
Supersedes #11.
Supersedes #13.

Testing done
===

Confirmed tests pass with Java 21 on Linux.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
